### PR TITLE
Fix issue during deployment.

### DIFF
--- a/src/mail-dispatcher.js
+++ b/src/mail-dispatcher.js
@@ -514,7 +514,8 @@ module.exports = class MailDispatcher {
                         ]
                     }
 
-                    var matches = data.Rules.filter((rule) => rule.Name === self.configuration.resourceName)
+                    var rules = data.Rules || []
+                    var matches = rules.filter((rule) => rule.Name === self.configuration.resourceName)
 
                     if (matches.length === 0) {
                         self.call(ses, 'createReceiptRule', {


### PR DESCRIPTION
When checking for existing rules, make sure to handle the return value if null or undefined (although the docs don't indicate this possibility).